### PR TITLE
Replace the nf90_open for parallel access with regular nf90_open

### DIFF
--- a/src/netcdf_io/interp_inc.fd/driver.F90
+++ b/src/netcdf_io/interp_inc.fd/driver.F90
@@ -250,8 +250,12 @@ call mpi_comm_size(mpi_comm_world, npes, mpierr)
 
  if (mype == npes-1) print*,'- OPEN INPUT FILE: ', trim(infile)
 
- error = nf90_open(trim(infile), ior(nf90_nowrite, nf90_mpiio), &
-                   comm=mpi_comm_world, info = mpi_info_null, ncid=ncid_in)
+ ! Opening for parallel access breaks gfsanalcalc & gdasanalcalc on S4
+ ! Also there is no parallel access, so there is no need to open for parallel
+ ! access. By Innocent.
+ !error = nf90_open(trim(infile), ior(nf90_nowrite, nf90_mpiio), &
+ !                  comm=mpi_comm_world, info = mpi_info_null, ncid=ncid_in)
+ error = nf90_open(trim(infile), ior(nf90_nowrite, nf90_mpiio), ncid=ncid_in)
  call netcdf_err(error, 'opening file='//trim(infile) )
 
  error = nf90_inq_dimid(ncid_in, 'lon', id_dim)

--- a/src/netcdf_io/interp_inc.fd/driver.F90
+++ b/src/netcdf_io/interp_inc.fd/driver.F90
@@ -250,9 +250,9 @@ call mpi_comm_size(mpi_comm_world, npes, mpierr)
 
  if (mype == npes-1) print*,'- OPEN INPUT FILE: ', trim(infile)
 
- ! Opening for parallel access breaks gfsanalcalc & gdasanalcalc on S4
+ ! Opening for parallel access breaks global workflow on S4
  ! Also there is no parallel access, so there is no need to open for parallel
- ! access. By Innocent.
+ ! access.
  !error = nf90_open(trim(infile), ior(nf90_nowrite, nf90_mpiio), &
  !                  comm=mpi_comm_world, info = mpi_info_null, ncid=ncid_in)
  error = nf90_open(trim(infile), ior(nf90_nowrite, nf90_mpiio), ncid=ncid_in)


### PR DESCRIPTION
* Replace the opening of netcdf file for parallel access by regular open
* The parallel access is not used in src/netcdf_io/interp_inc.fd/driver.F90
* Opening for parallel access breaks global-workflow on S4